### PR TITLE
Configuration file on the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ To validate these URLs, run `./node_modules/.bin/valimate` in your terminal or `
 
 All of the configuration options are listed on the [valimate.json wiki page](https://github.com/jamesseanwright/valimate/wiki/valimate.json).
 
+## Running with another configuration file 
+
+Run ./node_modules/.bin/valimate file.json in your terminal or valimate within the context of an npm script.
 
 ## Running against a local app server
 

--- a/valimate.js
+++ b/valimate.js
@@ -2,7 +2,8 @@
 
 'use strict';
 
-const config = require(process.cwd() + '/valimate.json');
+const file = process.argv[2] ? process.argv[2] : 'valimate.json';
+const config = require(process.cwd() + '/' + file);
 const valimate = require('./lib');
 
 valimate.validate(config, true);


### PR DESCRIPTION
With this modification it is possible to pass a configuration file
through the command line.

Example:

valimate file.json